### PR TITLE
Add privacy policy page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand page-scroll" href="#page-top">Foxtail</a>
+            <a class="navbar-brand" href="index.html">Foxtail</a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->
@@ -17,12 +17,9 @@
                 <li>
                     <a class="page-scroll" href="#about">About</a>
                 </li>
-                <!-- <li>
-                    <a class="page-scroll" href="#services">Services</a>
-                </li>
                 <li>
-                    <a class="page-scroll" href="#portfolio">Portfolio</a>
-                </li> -->
+                    <a href="privacy.html">Privacy</a>
+                </li>
                 <li>
                     <a class="page-scroll" href="#contact">Contact</a>
                 </li>

--- a/_includes/privacy_policy.html
+++ b/_includes/privacy_policy.html
@@ -1,0 +1,159 @@
+<section id="privacy" class="bg-dark">
+    <div class="container" style="padding-right:200px; padding-left:200px">
+        <h1>Privacy Policy</h1>
+        <p>This Privacy Policy describes how <strong>Foxtail</strong> (the "Site", "we", "us", or "our") collects, uses,
+            and discloses your personal information when you visit, use our services including <a
+                href="https://foxtailcreates.com">foxtailcreates.com</a> (the "Site") or otherwise communicate with us
+            (collectively, the "Services"). For purposes of this Privacy Policy, "you" and "your" means you as the user
+            of the Services, whether you are a customer, website visitor, or another individual whose information we
+            have collected pursuant to this Privacy Policy.</p>
+
+        <p>Please read this Privacy Policy carefully. By using and accessing any of the Services, you agree to the
+            collection, use, and disclosure of your information as described in this Privacy Policy. If you do not agree
+            to this Privacy Policy, please do not use or access any of the Services.</p>
+
+        <h2>Changes to This Privacy Policy</h2>
+        <p>We may update this Privacy Policy from time to time, including to reflect changes to our practices or for
+            other operational, legal, or regulatory reasons. We will post the revised Privacy Policy on the Site, update
+            the "Last updated" date and take any other steps required by applicable law.</p>
+
+        <h2>How We Collect and Use Your Personal Information</h2>
+        <p>To provide the Services, we collect personal information about you from a variety of sources, as set out
+            below. The information that we collect and use varies depending on how you interact with us.</p>
+        <p>In addition to the specific uses set out below, we may use information we collect about you to communicate
+            with you, provide the Services, comply with any applicable legal obligations, enforce any applicable terms
+            of service, and to protect or defend the Services, our rights, and the rights of our users or others.</p>
+
+        <h2>What Personal Information We Collect</h2>
+        <p>The types of personal information we obtain about you depend on how you interact with our Site and use our
+            Services. When we use the term "personal information", we are referring to information that identifies,
+            relates to, describes or can be associated with you. The following sections describe the categories and
+            specific types of personal information we collect.</p>
+
+        <h3>Information We Collect Directly from You</h3>
+        <p>When you install or purchase a product of Foxtail, as part of the installing or buying process, we are
+            automatically able to access certain types of information from your Shopify account:
+        </p>
+        <ul>
+            <li>User information: Store owner's name, Email address, Store Address, Phone</li>
+            <li>Store information: Store domain, Shopify plan, Products, Orders</li>
+            <li>Activity status of our product: install, uninstall, upgrade, downgrade</li>
+        </ul>
+
+        <h3>Information We Collect through Cookies</h3>
+        <p>We also automatically collect certain information about your interaction with the Services ("Usage Data"). To
+            do this, we may use cookies, pixels and similar technologies ("Cookies"). Usage Data may include information
+            about how you access and use our Site and your account, including device information, browser information,
+            information about your network connection, your IP address and other information regarding your interaction
+            with the Services.</p>
+
+        <h3>Information We Obtain from Third Parties</h3>
+        <p>Finally, we may obtain information about you from third parties, including from vendors and service providers
+            who may collect information on our behalf, such as:</p>
+        <ul>
+            <li>Companies who support our Site and Services, such as Shopify. When you visit our Site, open or click on
+                emails we send you, or interact with our Services or advertisements, we, or third parties we work with,
+                may automatically collect certain information using online tracking technologies such as pixels, web
+                beacons, software developer kits, third-party libraries, and cookies.</li>
+        </ul>
+        <p>Any information we obtain from third parties will be treated in accordance with this Privacy Policy. We are
+            not responsible or liable for the accuracy of the information provided to us by third parties and are not
+            responsible for any third party's policies or practices. For more information, see the section below,
+            <strong>Third Party Websites and Links</strong>.
+        </p>
+
+        <h2>How We Use Your Personal Information</h2>
+        <p><strong>Providing Products and Services:</strong> We use your personal information to provide you with the
+            Services in order to perform our contract with you, including to process your payments, fulfill your orders,
+            to send notifications to you related to you account, purchases, returns, exchanges or other transactions, to
+            create, maintain and otherwise manage your account, to arrange for shipping, facilitate any returns and
+            exchanges and to enable you to post reviews.</p>
+
+        <p><strong>Marketing and Advertising:</strong> We use your personal information for marketing and promotional
+            purposes, such as to send marketing, advertising and promotional communications by email, text message or
+            postal mail, and to show you advertisements for products or services. This may include using your personal
+            information to better tailor the Services and advertising on our Site and other websites.</p>
+
+        <p><strong>Communicating with you:</strong> We use your personal information to provide you with customer
+            support and improve our Services. This is in our legitimate interests in order to be responsive to you, to
+            provide effective services to you, and to maintain our business relationship with you.</p>
+
+        <h2>Cookies</h2>
+        <p>Like many websites, we use Cookies on our Site. For specific information about the Cookies that we use
+            related to powering our store with Shopify, see <a href="https://www.shopify.com/legal/cookies"
+                target="_blank">Shopify Cookie Policy</a>. We may use Cookies to power and improve our Site and our
+            Services (including to remember your actions and preferences), to run analytics and better understand user
+            interaction with the Services (in our legitimate interests to administer, improve and optimize the
+            Services).</p>
+
+        <p>Most browsers automatically accept Cookies by default, but you can choose to set your browser to remove or
+            reject Cookies through your browser controls. Please keep in mind that removing or blocking Cookies can
+            negatively impact your user experience and may cause some of the Services, including certain features and
+            general functionality, to work incorrectly or no longer be available.</p>
+
+        <h2>How We Disclose Personal Information</h2>
+        <p>In certain circumstances, we may disclose your personal information to third parties for legitimate purposes
+            subject to this Privacy Policy. Such circumstances may include:</p>
+        <ul>
+            <li>With vendors or other third parties who perform services on our behalf (e.g., IT management, payment
+                processing, data analytics, customer support, cloud storage, fulfillment and shipping).</li>
+            <li>In connection with a business transaction such as a merger or bankruptcy, to comply with any applicable
+                legal obligations (including to respond to subpoenas, search warrants and similar requests), to enforce
+                any applicable terms of service, and to protect or defend the Services, our rights, and the rights of
+                our users or others.</li>
+        </ul>
+        <p>We may disclose the following categories of personal information about users for the purposes set out above:
+        </p>
+        <ul>
+            <li>Identifiers such as basic contact details and certain account information</li>
+            <li>Internet or other similar network activity, such as Usage Data</li>
+        </ul>
+
+        <h2>E-Commerce</h2>
+        <p>Currently, all transactions in the app are handled via Shopify billing, and we do not collect any personal
+            and financial information.</p>
+
+        <h2>Third Party Websites and Links</h2>
+        <p>Our Site may provide links to websites or other online platforms operated by third parties. If you follow
+            links to sites not affiliated or controlled by us, you should review their privacy and security policies and
+            other terms and conditions. We do not guarantee and are not responsible for the privacy or security of such
+            sites, including the accuracy, completeness, or reliability of information found on these sites.</p>
+
+        <h2>Children's Data</h2>
+        <p>The Services are not intended to be used by children, and we do not knowingly collect any personal
+            information about children. If you are the parent or guardian of a child who has provided us with their
+            personal information, you may contact us using the contact details set out below to request that it be
+            deleted.</p>
+
+        <h2>Security and Retention of Your Information</h2>
+        <p>Please be aware that no security measures are perfect or impenetrable, and we cannot guarantee "perfect
+            security." Any information you send to us may not be secure while in transit.</p>
+
+        <h2>Your Rights and Choices</h2>
+        <p>Depending on where you live, you may have some or all of the rights listed below in relation to your personal
+            information. However, these rights are not absolute and may apply only in certain circumstances. These
+            include:</p>
+        <ul>
+            <li>Right to Access / Know</li>
+            <li>Right to Delete</li>
+            <li>Right to Correct</li>
+            <li>Right of Portability</li>
+            <li>Restriction of Processing</li>
+            <li>Withdrawal of Consent</li>
+        </ul>
+
+        <h2>Complaints</h2>
+        <p>If you have complaints about how we process your personal information, please contact us using the contact
+            details provided below.</p>
+
+        <h2>International Users</h2>
+        <p>We may transfer, store and process your personal information outside the country you live in, including the
+            United States. Your personal information is also processed by staff and third-party service providers and
+            partners in these countries.</p>
+
+        <h2>Contact</h2>
+        <p>If you have any questions about our privacy practices or this Privacy Policy, or if you would like to
+            exercise any of the rights available to you, please email us at <a
+                href="mailto:foxtailcreates@gmail.com">foxtailcreates@gmail.com</a>.</p>
+    </div>
+</section>

--- a/_layouts/privacy.html
+++ b/_layouts/privacy.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+{% include head.html %}
+
+<body id="page-top">
+  {% include nav.html %}
+  <!-- {% include header.html %} -->
+  {% include privacy_policy.html %}
+</body>
+
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,3 @@
+---
+layout: privacy
+---


### PR DESCRIPTION
Add privacy policy, which is a shopify app requirement.

Content drafted here: https://docs.google.com/document/d/1-kfYlhTvdmlf2ThxJWZgiTYy3GgZIAAqmu6MhXNsLdY/edit.
Then chatGPT was used for generating the html